### PR TITLE
chore: downgrade vite to stable v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "devDependencies": {
           "@types/node": "^20.10.0",
           "@vitejs/plugin-react-swc": "^3.10.2",
-          "vite": "6.3.5"
+          "vite": "^5.0.0"
       },
       "scripts": {
           "dev": "vite",


### PR DESCRIPTION
## Summary
- use Vite v5 instead of unreleased 6.x in devDependencies

## Testing
- `npm install` *(fails: Invalid package name "jsr:" of package "jsr:@^supabase")*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5705101fc8322a746382c5c2be76e