### PR TITLE
chore: add react type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
       },
       "devDependencies": {
           "@types/node": "^20.10.0",
+          "@types/react": "^18.3.3",
+          "@types/react-dom": "^18.3.1",
           "@vitejs/plugin-react-swc": "^3.10.2",
           "vite": "6.3.5"
       },


### PR DESCRIPTION
## Summary
- add `@types/react` and `@types/react-dom` to dev dependencies

## Testing
- `npm install` *(fails: Invalid package name "jsr:" of package "jsr:@^supabase" )*
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68b578f8b358832295d8b5366efd58a8