### PR TITLE
Use onKeyDown for MediaUploader URL input

### DIFF
--- a/src/components/MediaUploader.tsx
+++ b/src/components/MediaUploader.tsx
@@ -186,7 +186,7 @@ export function MediaUploader({
             onChange={(e) => setUrlInput(e.target.value)}
             placeholder="https://example.com/image.jpg or https://giphy.com/gifs/..."
             className="font-['Anonymous_Pro']"
-            onKeyPress={(e) => e.key === 'Enter' && handleUrlAdd()}
+            onKeyDown={e => e.key === 'Enter' && handleUrlAdd()}
           />
           <Button
             type="button"


### PR DESCRIPTION
## Summary
- update MediaUploader URL input to listen for Enter key via `onKeyDown` instead of deprecated `onKeyPress`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*
- `npm install --no-audit --no-fund` *(fails: Invalid package name "jsr:" of package "jsr:@^supabase"*)


------
https://chatgpt.com/codex/tasks/task_e_68b57bb275408322bbbd147435fdd566