### PR TITLE
fix: use relative path for main script

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
     <body>
       <div id="root"></div>
-      <script type="module" src="/src/main.tsx"></script>
+      <script type="module" src="./src/main.tsx"></script>
     </body>
   </html>
   


### PR DESCRIPTION
## Summary
- use relative path for main script in `index.html`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: Invalid package name "jsr:")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57bad1120832281b59008d9c28d78