### PR TITLE
Fix avatar preview and heading fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Anonymous+Pro:wght@400;700&family=Inter:wght@400;700&display=swap" rel="stylesheet" />
-    <link href="https://fonts.cdnfonts.com/css/feature-mono" rel="stylesheet" />
   </head>
 
     <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
         <div className="fixed top-0 left-0 right-0 z-50 bg-white/10 backdrop-blur-md border-b border-white/20">
           <div className="container mx-auto px-8 py-4">
             <div className="flex items-center justify-between">
-              <h1 className="font-['Feature_Mono'] text-xl text-[#323232] uppercase tracking-wider">
+              <h1 className="font-['Anonymous_Pro'] text-xl text-[#323232] uppercase tracking-wider">
                 Portfolio Admin
               </h1>
               <Button

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -116,7 +116,7 @@ export function Hero({ onUnlockAdmin }: { onUnlockAdmin?: () => void }) {
           >
             <div className="space-y-4">
               <motion.h1
-                className="font-['Feature_Mono'] tracking-[0.2em] uppercase text-[#323232]"
+                className="font-['Anonymous_Pro'] tracking-[0.2em] uppercase text-[#323232]"
                 style={{ fontSize: 'clamp(4rem, 8vw, 10rem)', fontWeight: 'bold', lineHeight: '0.9' }}
                 initial={{ opacity: 0, y: 30 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/src/components/HeroAdmin.tsx
+++ b/src/components/HeroAdmin.tsx
@@ -157,7 +157,7 @@ export function HeroAdmin() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="font-['Feature_Mono'] text-2xl text-[#323232] uppercase tracking-wider">
+          <h2 className="font-['Anonymous_Pro'] text-2xl text-[#323232] uppercase tracking-wider">
             Hero Management
           </h2>
           <p className="text-[#666] font-['Anonymous_Pro'] mt-2">

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -208,7 +208,7 @@ export function PortfolioLibrary() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
         >
-          <h2 className="font-['Feature_Mono'] text-6xl md:text-7xl text-[#323232] uppercase tracking-[0.3em] mb-4">
+          <h2 className="font-['Anonymous_Pro'] text-6xl md:text-7xl text-[#323232] uppercase tracking-[0.3em] mb-4">
             Portfolio
           </h2>
           <div className="w-24 h-1 bg-gradient-to-r from-[#323232] to-transparent mx-auto mb-6" />

--- a/src/components/ProjectAdmin.tsx
+++ b/src/components/ProjectAdmin.tsx
@@ -224,7 +224,7 @@ export function ProjectAdmin() {
             
             <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto bg-white/95 backdrop-blur-md">
               <DialogHeader>
-                <DialogTitle className="font-['Feature_Mono'] text-2xl text-[#323232] uppercase tracking-wider">
+                <DialogTitle className="font-['Anonymous_Pro'] text-2xl text-[#323232] uppercase tracking-wider">
                   {editingProject ? 'Edit Project' : 'Add New Project'}
                 </DialogTitle>
                 <DialogDescription className="font-['Anonymous_Pro'] text-[#323232]/70 uppercase tracking-wide text-sm">

--- a/src/components/ProjectModalHero.tsx
+++ b/src/components/ProjectModalHero.tsx
@@ -53,7 +53,7 @@ export function ProjectModalHero({
             )}
           </div>
           
-          <h1 className="text-5xl md:text-6xl font-['Feature_Mono'] text-white mb-6 uppercase tracking-wider leading-tight">
+          <h1 className="text-5xl md:text-6xl font-['Anonymous_Pro'] text-white mb-6 uppercase tracking-wider leading-tight">
             {safeTitle}
           </h1>
           

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as AvatarPrimitive from "@radix-ui/react-avatar@1.1.3";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
 import { cn } from "./utils";
 
@@ -27,6 +27,7 @@ function AvatarImage({
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
     <AvatarPrimitive.Image
+      key={props.src}
       data-slot="avatar-image"
       className={cn("aspect-square size-full", className)}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -3190,13 +3190,9 @@
     font-family: Anonymous Pro\:Regular, sans-serif;
   }
 
-  .font-\[\'Feature_Mono\'\] {
-    font-family: Feature Mono;
-  }
-
-  .font-\[\'Inter\'\] {
-    font-family: Inter;
-  }
+    .font-\[\'Inter\'\] {
+      font-family: Inter;
+    }
 
   .font-\[\'Inter\:Bold\'\,_sans-serif\] {
     font-family: Inter\:Bold, sans-serif;


### PR DESCRIPTION
## Summary
- Fix avatar image state so uploaded avatars remain visible
- Use Anonymous Pro for headings and drop external Feature Mono font

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9ab3dee48322a827def16ea4cc4c