### PR TITLE
feat: enable lazy image loading

### DIFF
--- a/src/components/CoverImageUploader.tsx
+++ b/src/components/CoverImageUploader.tsx
@@ -154,32 +154,33 @@ export function CoverImageUploader({
       {value && (
         <Card className="bg-white/10 backdrop-blur-md border-white/20">
           <CardContent className="p-4">
-            <div className="flex items-start gap-4">
-              <div className="flex-1">
-                <div className="aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2 max-w-xs">
-                  <img 
-                    src={value} 
-                    alt="Cover preview" 
-                    className="w-full h-full object-cover"
-                  />
+              <div className="flex items-start gap-4">
+                <div className="flex-1">
+                  <div className="aspect-video bg-gray-100 rounded-lg overflow-hidden mb-2 max-w-xs">
+                    <img
+                      src={value}
+                      alt="Cover preview"
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <ImageIcon className="w-4 h-4 text-blue-600" />
+                    <span className="font-['Anonymous_Pro'] text-sm text-[#323232] truncate">
+                      {value.startsWith('blob:') ? 'Uploaded image' : value}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <ImageIcon className="w-4 h-4 text-blue-600" />
-                  <span className="font-['Anonymous_Pro'] text-sm text-[#323232] truncate">
-                    {value.startsWith('blob:') ? 'Uploaded image' : value}
-                  </span>
-                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleRemove}
+                  className="text-red-600 hover:text-red-700"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
               </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                onClick={handleRemove}
-                className="text-red-600 hover:text-red-700"
-              >
-                <X className="w-4 h-4" />
-              </Button>
-            </div>
           </CardContent>
         </Card>
       )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -103,6 +103,7 @@ export function Hero({ onUnlockAdmin }: { onUnlockAdmin?: () => void }) {
                 alt={`${heroData.name} - ${heroData.title}`}
                 className="w-full max-w-md mx-auto rounded-2xl shadow-2xl object-cover aspect-[4/5]"
                 onClick={handleImageClick}
+                loading="lazy"
               />
             </div>
           </motion.div>

--- a/src/components/MediaUploader.tsx
+++ b/src/components/MediaUploader.tsx
@@ -152,10 +152,11 @@ export function MediaUploader({
                   muted
                 />
               ) : (
-                <img 
-                  src={item.url} 
-                  alt={item.name || 'Media'} 
+                <img
+                  src={item.url}
+                  alt={item.name || 'Media'}
                   className="w-full h-full object-cover"
+                  loading="lazy"
                 />
               )}
             </div>

--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -10,7 +10,15 @@ export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElemen
     setDidError(true)
   }
 
-  const { src, alt, style, className, ...rest } = props
+  const {
+    src,
+    alt,
+    style,
+    className,
+    decoding = 'async',
+    loading = 'lazy',
+    ...rest
+  } = props
 
   return didError ? (
     <div
@@ -18,10 +26,26 @@ export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElemen
       style={style}
     >
       <div className="flex items-center justify-center w-full h-full">
-        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+        <img
+          src={ERROR_IMG_SRC}
+          alt="Error loading image"
+          decoding={decoding}
+          loading={loading}
+          {...rest}
+          data-original-url={src}
+        />
       </div>
     </div>
   ) : (
-    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      style={style}
+      decoding={decoding}
+      loading={loading}
+      {...rest}
+      onError={handleError}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- default to async decoding and lazy loading in ImageWithFallback
- add lazy loading to direct image elements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be62daa61c83229cddbf97ab1fd98f