### PR TITLE
feat: add mobile filter drawer

### DIFF
--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -5,6 +5,7 @@ import { Switch } from './ui/switch';
 import { Checkbox } from './ui/checkbox';
 import { Grid, List, Star, X } from 'lucide-react';
 import { motion } from 'motion/react';
+import { cn } from './ui/utils';
 import { CATEGORIES, YEARS } from '../utils/constants';
 
 interface FilterControlsProps {
@@ -20,6 +21,7 @@ interface FilterControlsProps {
   onTopToggle: () => void;
   view: 'grid' | 'list';
   onViewChange: (view: 'grid' | 'list') => void;
+  className?: string;
 }
 
 export function FilterControls({
@@ -35,6 +37,7 @@ export function FilterControls({
   onTopToggle,
   view,
   onViewChange,
+  className,
 }: FilterControlsProps) {
   const handleCategoryToggle = (categoryId: string) => {
     const newCategories = selectedCategories.includes(categoryId)
@@ -48,12 +51,13 @@ export function FilterControls({
   };
 
   return (
-    <motion.div
-      className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 space-y-6"
-      initial={{ opacity: 0, x: -20 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.5 }}
-    >
+    <div className={cn('hidden lg:block', className)}>
+      <motion.div
+        className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-4 sm:p-6 space-y-6"
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.5 }}
+      >
       {/* View Toggle */}
       <div className="space-y-3">
         <h3 className="font-['Anonymous_Pro'] text-sm text-[#323232] uppercase tracking-wider">View</h3>
@@ -207,6 +211,7 @@ export function FilterControls({
           </Button>
         )}
       </div>
-    </motion.div>
+      </motion.div>
+    </div>
   );
 }

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -7,6 +7,9 @@ import { FilterControls } from './FilterControls';
 import { LoadingState, ErrorState, EmptyState } from './LoadingState';
 import { projectApi, type Project } from '../utils/api';
 import { FALLBACK_PROJECTS, FALLBACK_TAGS } from '../utils/constants';
+import { Button } from './ui/button';
+import { Drawer, DrawerTrigger, DrawerContent } from './ui/drawer';
+import { Filter } from 'lucide-react';
 
 export function PortfolioLibrary() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
@@ -22,6 +25,7 @@ export function PortfolioLibrary() {
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [usingFallbackData, setUsingFallbackData] = useState(false);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   // Load projects and tags from API
   useEffect(() => {
@@ -165,6 +169,20 @@ export function PortfolioLibrary() {
     setSelectedProject(null);
   };
 
+  const filterControlsProps = {
+    selectedCategories,
+    onCategoriesChange: setSelectedCategories,
+    selectedYear,
+    onYearChange: setSelectedYear,
+    selectedTags,
+    onTagToggle: handleTagToggle,
+    availableTags,
+    showTopOnly,
+    onTopToggle: () => setShowTopOnly(!showTopOnly),
+    view,
+    onViewChange: setView,
+  };
+
   return (
     <section data-section="portfolio" className="min-h-screen py-20 relative overflow-hidden">
       {/* Background with glass effects */}
@@ -230,23 +248,21 @@ export function PortfolioLibrary() {
           )}
         </motion.div>
 
+        <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
+          <DrawerTrigger asChild>
+            <Button variant="outline" size="icon" className="mb-8 lg:hidden">
+              <Filter className="h-4 w-4" />
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent className="p-4">
+            <FilterControls {...filterControlsProps} className="block" />
+          </DrawerContent>
+        </Drawer>
+
         <div className="grid lg:grid-cols-4 gap-8">
           {/* Filters Sidebar */}
-          <div className="lg:col-span-1">
-            <FilterControls
-              selectedCategories={selectedCategories}
-              onCategoriesChange={setSelectedCategories}
-              selectedYear={selectedYear}
-              onYearChange={setSelectedYear}
-
-              selectedTags={selectedTags}
-              onTagToggle={handleTagToggle}
-              availableTags={availableTags}
-              showTopOnly={showTopOnly}
-              onTopToggle={() => setShowTopOnly(!showTopOnly)}
-              view={view}
-              onViewChange={setView}
-            />
+          <div className="lg:col-span-1 hidden lg:block">
+            <FilterControls {...filterControlsProps} />
           </div>
 
           {/* Projects Grid/List */}


### PR DESCRIPTION
## Summary
- hide filter panel on small screens and add responsive padding
- add mobile drawer with filter controls trigger button

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68be62ee5304832292d2b4ddc68bc91c