### PR TITLE
chore: limit console logs to development

### DIFF
--- a/src/components/ApiDebug.tsx
+++ b/src/components/ApiDebug.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { projectApi } from '../utils/api';
 import { projectId, publicAnonKey } from '../utils/supabase/info';
 import { Badge } from './ui/badge';
+import devLog from '../utils/devLog';
 
 export function ApiDebug() {
   const [debugInfo, setDebugInfo] = useState<any>({});
@@ -18,7 +19,7 @@ export function ApiDebug() {
 
       try {
         // Test health check
-        console.log('Testing health check...');
+        devLog('Testing health check...');
         const healthResult = await projectApi.healthCheck();
         info.healthCheck = {
           success: healthResult.success,
@@ -35,7 +36,7 @@ export function ApiDebug() {
 
       try {
         // Test projects fetch
-        console.log('Testing projects fetch...');
+        devLog('Testing projects fetch...');
         const projects = await projectApi.getProjects();
         info.projects = { count: projects.length, success: true };
       } catch (error) {
@@ -44,7 +45,7 @@ export function ApiDebug() {
 
       try {
         // Test tags fetch
-        console.log('Testing tags fetch...');
+        devLog('Testing tags fetch...');
         const tags = await projectApi.getTags();
         info.tags = { count: tags.length, success: true };
       } catch (error) {

--- a/src/components/CaseContentBlocks.tsx
+++ b/src/components/CaseContentBlocks.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { MediaUploader } from './MediaUploader';
 import { Plus, Trash2, MoveUp, MoveDown, Type, FileText, Image } from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
+import devLog from '../utils/devLog';
 
 export interface MediaItem {
   id: string;
@@ -50,7 +51,7 @@ export function CaseContentBlocks({
   };
 
   const updateBlock = (id: string, updates: Partial<ContentBlock>) => {
-    console.log(`Updating block ${id}:`, updates);
+    devLog(`Updating block ${id}:`, updates);
     const updatedBlocks = blocks.map(block => 
       block.id === id ? { ...block, ...updates } : block
     );

--- a/src/components/HeroAdmin.tsx
+++ b/src/components/HeroAdmin.tsx
@@ -11,6 +11,7 @@ import { Save, RefreshCcw, User, FileText, Link, Settings } from 'lucide-react';
 import { motion } from 'motion/react';
 import { projectId, publicAnonKey } from '../utils/supabase/info';
 import defaultHeroImage from '@/assets/2b3e7bb5588c3528566a362c8af4a578b7ffaf86.png';
+import devLog from '../utils/devLog';
 
 interface HeroData {
   name: string;
@@ -50,7 +51,7 @@ export function HeroAdmin() {
   const loadHeroData = async () => {
     try {
       setLoading(true);
-      console.log('Loading hero data from API...');
+      devLog('Loading hero data from API...');
       
       const response = await fetch(`https://${projectId}.supabase.co/functions/v1/make-server-32d29310/hero`, {
         headers: {
@@ -63,7 +64,7 @@ export function HeroAdmin() {
       }
       
       const result = await response.json();
-      console.log('Hero API response:', result);
+      devLog('Hero API response:', result);
       
       if (result.success) {
         setHeroData(result.hero || DEFAULT_HERO_DATA);
@@ -97,7 +98,7 @@ export function HeroAdmin() {
   const saveHeroData = async () => {
     try {
       setSaving(true);
-      console.log('Saving hero data:', heroData);
+      devLog('Saving hero data:', heroData);
       
       const response = await fetch(`https://${projectId}.supabase.co/functions/v1/make-server-32d29310/hero`, {
         method: 'PUT',
@@ -113,7 +114,7 @@ export function HeroAdmin() {
       }
       
       const result = await response.json();
-      console.log('Save hero response:', result);
+      devLog('Save hero response:', result);
       
       if (result.success) {
         setHeroData(result.hero);

--- a/src/components/MediaUploader.tsx
+++ b/src/components/MediaUploader.tsx
@@ -5,6 +5,7 @@ import { Label } from './ui/label';
 import { Card, CardContent } from './ui/card';
 import { Upload, X, Image, Film } from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
+import devLog from '../utils/devLog';
 
 interface MediaItem {
   id: string;
@@ -56,7 +57,7 @@ export function MediaUploader({
       name: urlInput.split('/').pop()?.split('?')[0] || 'Media'
     };
 
-    console.log(`Adding media to block ${blockId}:`, newMedia);
+    devLog(`Adding media to block ${blockId}:`, newMedia);
     onMediaChange([...media, newMedia]);
     setUrlInput('');
     toast.success('Media added successfully');
@@ -102,7 +103,7 @@ export function MediaUploader({
           name: file.name
         };
         
-        console.log(`Adding file to block ${blockId}:`, mediaItem);
+        devLog(`Adding file to block ${blockId}:`, mediaItem);
         
         newMediaItems.push(mediaItem);
       }
@@ -126,7 +127,7 @@ export function MediaUploader({
   };
 
   const handleRemove = (id: string) => {
-    console.log(`Removing media ${id} from block ${blockId}`);
+    devLog(`Removing media ${id} from block ${blockId}`);
     const updatedMedia = media.filter(item => item.id !== id);
     onMediaChange(updatedMedia);
     toast.success('Media removed');

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -7,6 +7,7 @@ import { FilterControls } from './FilterControls';
 import { LoadingState, ErrorState, EmptyState } from './LoadingState';
 import { projectApi, type Project } from '../utils/api';
 import { FALLBACK_PROJECTS, FALLBACK_TAGS } from '../utils/constants';
+import devLog from '../utils/devLog';
 
 export function PortfolioLibrary() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
@@ -31,7 +32,7 @@ export function PortfolioLibrary() {
         setError(null);
         setUsingFallbackData(false);
         
-        console.log('Starting to load portfolio data...');
+        devLog('Starting to load portfolio data...');
         
         // Try to load data from API
         const [projectsData, tagsData] = await Promise.all([
@@ -39,14 +40,14 @@ export function PortfolioLibrary() {
           projectApi.getTags()
         ]);
         
-        console.log('Loaded projects from API:', projectsData);
-        console.log('Loaded tags from API:', tagsData);
+        devLog('Loaded projects from API:', projectsData);
+        devLog('Loaded tags from API:', tagsData);
         
         // Validate and use API data if available
         if (Array.isArray(projectsData) && projectsData.length > 0) {
           setProjects(projectsData);
           setAvailableTags(Array.isArray(tagsData) ? tagsData : []);
-          console.log('Using API data successfully');
+          devLog('Using API data successfully');
         } else {
           throw new Error('No projects returned from API');
         }
@@ -55,9 +56,9 @@ export function PortfolioLibrary() {
         
         // Immediately use fallback data when API fails
         try {
-          console.log('Loading fallback data...');
-          console.log('Fallback projects:', FALLBACK_PROJECTS);
-          console.log('Fallback tags:', FALLBACK_TAGS);
+          devLog('Loading fallback data...');
+          devLog('Fallback projects:', FALLBACK_PROJECTS);
+          devLog('Fallback tags:', FALLBACK_TAGS);
           
           // Validate fallback data structure
           const validFallbackProjects = FALLBACK_PROJECTS.filter(project => {
@@ -79,7 +80,7 @@ export function PortfolioLibrary() {
             setAvailableTags(Array.isArray(FALLBACK_TAGS) ? FALLBACK_TAGS : []);
             setUsingFallbackData(true);
             setError(null); // Clear any error since fallback worked
-            console.log(`Successfully loaded ${validFallbackProjects.length} fallback projects`);
+            devLog(`Successfully loaded ${validFallbackProjects.length} fallback projects`);
           } else {
             throw new Error('Fallback data validation failed');
           }

--- a/src/components/ProjectAdmin.tsx
+++ b/src/components/ProjectAdmin.tsx
@@ -18,6 +18,7 @@ import { TagInput } from './TagInput';
 import { CategorySelector } from './CategorySelector';
 import { Plus, Edit2, Trash2, Save, X, FileText, Layout } from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
+import devLog from '../utils/devLog';
 
 interface ProjectFormData {
   name: string;
@@ -95,7 +96,7 @@ export function ProjectAdmin() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    console.log('Submitting project with content blocks:', formData.contentBlocks);
+    devLog('Submitting project with content blocks:', formData.contentBlocks);
     
     try {
       if (editingProject) {
@@ -425,7 +426,7 @@ export function ProjectAdmin() {
                       <CaseContentBlocks
                         blocks={formData.contentBlocks}
                         onBlocksChange={(blocks) => {
-                          console.log('Content blocks changed:', blocks);
+                          devLog('Content blocks changed:', blocks);
                           setFormData({ ...formData, contentBlocks: blocks });
                         }}
                       />

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -9,6 +9,7 @@ import { ProjectModalContent } from './ProjectModalContent';
 import { ProjectModalImageViewer } from './ProjectModalImageViewer';
 import { getSafeProjectData, getCategoryLabels, getProjectImage, getGalleryImages } from '../utils/projectModalHelpers';
 import type { ProjectModalProps } from '../utils/projectModalConstants';
+import devLog from '../utils/devLog';
 
 export function ProjectModal({ project, isOpen, onClose }: ProjectModalProps) {
   const [selectedImageIndex, setSelectedImageIndex] = useState<number>(-1);
@@ -26,7 +27,7 @@ export function ProjectModal({ project, isOpen, onClose }: ProjectModalProps) {
   } = getSafeProjectData(project);
 
   // Debug content blocks
-  console.log('ProjectModal - Content blocks for project:', safeTitle, safeContentBlocks);
+  devLog('ProjectModal - Content blocks for project:', safeTitle, safeContentBlocks);
 
   const categoryLabels = getCategoryLabels(safeCategories);
   const projectImage = getProjectImage(project, safeCategories);

--- a/src/supabase/functions/server/index.tsx
+++ b/src/supabase/functions/server/index.tsx
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import { createClient } from '@supabase/supabase-js';
 import { initializeDatabase } from './initialization.tsx';
 import * as routes from './routes.tsx';
+import devLog from '../../../utils/devLog.ts';
 
 const app = new Hono();
 
@@ -14,7 +15,7 @@ app.use('*', cors({
   allowHeaders: ['Content-Type', 'Authorization'],
 }));
 
-app.use('*', logger(console.log));
+app.use('*', logger(devLog));
 
 // Initialize Supabase client
 const supabase = createClient(
@@ -23,27 +24,27 @@ const supabase = createClient(
 );
 
 // Initialize database on startup
-console.log('Server starting up...');
-console.log('Environment check:');
-console.log('- SUPABASE_URL:', Deno.env.get('SUPABASE_URL') ? 'Set' : 'Missing');
-console.log('- SUPABASE_SERVICE_ROLE_KEY:', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ? 'Set' : 'Missing');
+devLog('Server starting up...');
+devLog('Environment check:');
+devLog('- SUPABASE_URL:', Deno.env.get('SUPABASE_URL') ? 'Set' : 'Missing');
+devLog('- SUPABASE_SERVICE_ROLE_KEY:', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ? 'Set' : 'Missing');
 
 // Initialize database and projects (with better error handling)
 const initializeApp = async () => {
   try {
-    console.log('Initializing database...');
+    devLog('Initializing database...');
     await initializeDatabase();
-    console.log('Database initialization completed successfully');
+    devLog('Database initialization completed successfully');
   } catch (error) {
     console.error('Database initialization failed:', error);
-    console.log('Server will continue in fallback mode with sample data');
+    devLog('Server will continue in fallback mode with sample data');
   }
 };
 
 // Initialize asynchronously but don't block server startup
 initializeApp().catch((error) => {
   console.error('Async initialization error:', error);
-  console.log('Server continuing in fallback mode');
+  devLog('Server continuing in fallback mode');
 });
 
 // Routes
@@ -69,6 +70,6 @@ app.get('/', (c) => {
   });
 });
 
-console.log('Routes registered successfully');
-console.log('Starting Deno server...');
+devLog('Routes registered successfully');
+devLog('Starting Deno server...');
 Deno.serve(app.fetch);

--- a/src/supabase/functions/server/initialization.tsx
+++ b/src/supabase/functions/server/initialization.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import * as kv from './kv_store.tsx';
 import { SAMPLE_PROJECTS } from './constants.tsx';
+import devLog from '../../../utils/devLog.ts';
 
 // Initialize database table and sample data
 export const initializeDatabase = async () => {
@@ -10,33 +11,33 @@ export const initializeDatabase = async () => {
   );
 
   try {
-    console.log('Checking KV store table...');
+    devLog('Checking KV store table...');
     
     // Check if table exists and is accessible
     const tableExists = await kv.ensureTable();
     
     if (!tableExists) {
-      console.log('KV table is not available. Server will work with fallback data.');
+      devLog('KV table is not available. Server will work with fallback data.');
       return;
     }
 
     // Test basic KV operations
-    console.log('Testing KV store operations...');
+    devLog('Testing KV store operations...');
     const testResult = await kv.testConnection();
     
     if (!testResult) {
-      console.log('KV store test failed. Server will work with fallback data.');
+      devLog('KV store test failed. Server will work with fallback data.');
       return;
     }
     
-    console.log('KV store test passed');
+    devLog('KV store test passed');
 
     // Initialize projects if needed
     await initializeProjects();
 
   } catch (error) {
     console.error('Database initialization error:', error);
-    console.log('Server will continue with fallback data mode');
+    devLog('Server will continue with fallback data mode');
     // Don't throw error - let server continue with fallback
   }
 };
@@ -44,20 +45,20 @@ export const initializeDatabase = async () => {
 // Initialize with sample projects
 const initializeProjects = async () => {
   try {
-    console.log('Checking if projects are already initialized...');
+    devLog('Checking if projects are already initialized...');
     const existingProjects = await kv.get('projects:initialized');
     if (existingProjects) {
-      console.log('Projects already initialized, skipping...');
+      devLog('Projects already initialized, skipping...');
       return;
     }
 
-    console.log('Initializing sample projects...');
+    devLog('Initializing sample projects...');
 
     // Store each project
-    console.log(`Storing ${SAMPLE_PROJECTS.length} projects...`);
+    devLog(`Storing ${SAMPLE_PROJECTS.length} projects...`);
     for (const project of SAMPLE_PROJECTS) {
       await kv.set(`project:${project.id}`, project);
-      console.log(`Stored project: ${project.name}`);
+      devLog(`Stored project: ${project.name}`);
     }
 
     // Store project IDs for easy retrieval
@@ -65,10 +66,10 @@ const initializeProjects = async () => {
     await kv.set('project:ids', projectIds);
     await kv.set('projects:initialized', true);
 
-    console.log(`Sample projects initialized successfully. Stored ${projectIds.length} project IDs:`, projectIds);
+    devLog(`Sample projects initialized successfully. Stored ${projectIds.length} project IDs:`, projectIds);
   } catch (error) {
     console.error('Error initializing projects:', error);
     // Don't throw - let the application continue
-    console.log('Continuing without sample data initialization');
+    devLog('Continuing without sample data initialization');
   }
 };

--- a/src/supabase/functions/server/kv_store.tsx
+++ b/src/supabase/functions/server/kv_store.tsx
@@ -11,6 +11,7 @@ CREATE INDEX IF NOT EXISTS idx_kv_store_32d29310_key ON kv_store_32d29310(key);
 */
 
 import { createClient } from "@supabase/supabase-js";
+import devLog from '../../../utils/devLog.ts';
 
 const client = () => createClient(
   Deno.env.get("SUPABASE_URL"),
@@ -26,7 +27,7 @@ const handleDbError = (error: any, operation: string): Error => {
       error.message?.includes('Error code 525') ||
       error.message?.includes('<!DOCTYPE html>') ||
       error.message?.includes('Cloudflare')) {
-    console.log(`SSL/Connection error detected during ${operation}, switching to fallback mode`);
+    devLog(`SSL/Connection error detected during ${operation}, switching to fallback mode`);
     return new Error(`Database connection unavailable (SSL issue), using fallback mode`);
   }
   
@@ -43,7 +44,7 @@ const handleDbError = (error: any, operation: string): Error => {
       error.message?.includes('network') ||
       error.message?.includes('timeout') ||
       error.message?.includes('ECONNREFUSED')) {
-    console.log(`Network error detected during ${operation}, switching to fallback mode`);
+    devLog(`Network error detected during ${operation}, switching to fallback mode`);
     return new Error(`Database connection unavailable (network issue), using fallback mode`);
   }
   
@@ -233,9 +234,9 @@ export const testConnection = async (): Promise<boolean> => {
         error.message?.includes('Error code 525') ||
         error.message?.includes('<!DOCTYPE html>') ||
         error.message?.includes('Cloudflare')) {
-      console.log('SSL/Cloudflare connection issue detected - application will run in fallback mode');
+      devLog('SSL/Cloudflare connection issue detected - application will run in fallback mode');
     } else if (error.message?.includes('Database connection unavailable')) {
-      console.log('Database connection issue detected - application will run in fallback mode');
+      devLog('Database connection issue detected - application will run in fallback mode');
     }
     
     return false;
@@ -255,9 +256,9 @@ export const ensureTable = async (): Promise<boolean> => {
     
     if (error) {
       if (error.message?.includes('does not exist')) {
-        console.log('Table kv_store_32d29310 does not exist');
-        console.log('Please create it manually in Supabase dashboard with this SQL:');
-        console.log(`
+        devLog('Table kv_store_32d29310 does not exist');
+        devLog('Please create it manually in Supabase dashboard with this SQL:');
+        devLog(`
           CREATE TABLE kv_store_32d29310 (
             key TEXT NOT NULL PRIMARY KEY,
             value JSONB NOT NULL,
@@ -272,7 +273,7 @@ export const ensureTable = async (): Promise<boolean> => {
       return false;
     }
     
-    console.log('Table kv_store_32d29310 exists and is accessible');
+    devLog('Table kv_store_32d29310 exists and is accessible');
     return true;
   } catch (error) {
     console.error('Error checking table existence:', error);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,6 @@
 import { projectId, publicAnonKey } from './supabase/info';
 import { FALLBACK_PROJECTS } from './constants';
+import devLog from './devLog';
 
 export interface MediaItem {
   id: string;
@@ -123,9 +124,9 @@ const transformApiProject = (apiProject: ApiProject): Project => {
 
 const apiCall = async (endpoint: string, options: RequestInit = {}) => {
   const url = `${API_BASE_URL}${endpoint}`;
-  console.log(`Making API call to: ${url}`);
-  console.log(`Project ID: ${projectId}`);
-  console.log(`Public Anon Key: ${publicAnonKey}`);
+  devLog(`Making API call to: ${url}`);
+  devLog(`Project ID: ${projectId}`);
+  devLog(`Public Anon Key: ${publicAnonKey}`);
   
   try {
     const response = await fetch(url, {
@@ -137,8 +138,8 @@ const apiCall = async (endpoint: string, options: RequestInit = {}) => {
       },
     });
 
-    console.log(`Response status: ${response.status}`);
-    console.log(`Response ok: ${response.ok}`);
+    devLog(`Response status: ${response.status}`);
+    devLog(`Response ok: ${response.ok}`);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -152,7 +153,7 @@ const apiCall = async (endpoint: string, options: RequestInit = {}) => {
       
       // Check for specific connectivity issues
       if (response.status === 503 && errorData.fallbackMode) {
-        console.log('API returned 503 with fallback mode - database connectivity issues');
+        devLog('API returned 503 with fallback mode - database connectivity issues');
         throw new Error(`Database connectivity issue: ${errorData.message || 'Database unavailable'}`);
       }
       
@@ -160,11 +161,11 @@ const apiCall = async (endpoint: string, options: RequestInit = {}) => {
     }
 
     const result = await response.json();
-    console.log(`API Success Response:`, result);
+    devLog(`API Success Response:`, result);
     
     // Log if we're running in fallback mode
     if (result.fallbackMode) {
-      console.log('API is running in fallback mode:', result.message);
+      devLog('API is running in fallback mode:', result.message);
     }
     
     return result;
@@ -191,11 +192,11 @@ export const projectApi = {
       const result = await apiCall('/projects');
       const apiProjects = result.projects || [];
       
-      console.log('Raw API projects:', apiProjects);
+      devLog('Raw API projects:', apiProjects);
       
       // If we got fallback data, it might already be in the correct format
       if (result.message && result.message.includes('fallback')) {
-        console.log('Using fallback data from server');
+        devLog('Using fallback data from server');
         // Try to transform if needed, otherwise return as-is
         try {
           const transformedProjects = apiProjects
@@ -209,7 +210,7 @@ export const projectApi = {
               return transformApiProject(project);
             });
           
-          console.log('Transformed fallback projects:', transformedProjects);
+          devLog('Transformed fallback projects:', transformedProjects);
           return transformedProjects;
         } catch (transformError) {
           console.warn('Failed to transform fallback data, using local fallback:', transformError);
@@ -230,11 +231,11 @@ export const projectApi = {
         })
         .filter((project: Project | null): project is Project => project !== null);
       
-      console.log('Transformed projects:', transformedProjects);
+      devLog('Transformed projects:', transformedProjects);
       return transformedProjects;
     } catch (error) {
       console.error('Error fetching projects, using fallback data:', error);
-      console.log('Returning local fallback projects');
+      devLog('Returning local fallback projects');
       return FALLBACK_PROJECTS;
     }
   },

--- a/src/utils/devLog.ts
+++ b/src/utils/devLog.ts
@@ -1,0 +1,12 @@
+declare const Deno: any;
+
+export const devLog = (...args: unknown[]): void => {
+  if (
+    (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') ||
+    (typeof Deno !== 'undefined' && Deno.env.get('NODE_ENV') === 'development')
+  ) {
+    console.log(...args);
+  }
+};
+
+export default devLog;


### PR DESCRIPTION
## Summary
- add `devLog` utility that only logs in development
- wrap or replace all `console.log` calls in components, utilities, and server functions with the new helper
- keep warnings and errors intact for production visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be62f743b48322bdc053e396bfa979