### PR TITLE
feat: upload media to supabase storage

### DIFF
--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+import { projectId, publicAnonKey } from './info';
+
+const supabaseUrl = `https://${projectId}.supabase.co`;
+
+export const supabase = createClient(supabaseUrl, publicAnonKey);


### PR DESCRIPTION
## Summary
- add reusable Supabase client
- store uploaded media in Supabase Storage and use public URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be6cc1bec88322a25e7ae9f6fc4125