### PR TITLE
Ensure filters visible on desktop by default

### DIFF
--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -51,7 +51,7 @@ export function FilterControls({
   };
 
   return (
-    <div className={cn('block', className)}>
+    <div className={cn(className)}>
       <motion.div
         className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-4 sm:p-6 space-y-6"
         initial={{ opacity: 0, x: -20 }}

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -51,7 +51,7 @@ export function FilterControls({
   };
 
   return (
-    <div className={cn('hidden lg:block', className)}>
+    <div className={cn('block', className)}>
       <motion.div
         className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-4 sm:p-6 space-y-6"
         initial={{ opacity: 0, x: -20 }}

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -250,7 +250,7 @@ export function PortfolioLibrary() {
 
         <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
           <DrawerTrigger asChild>
-            <Button variant="outline" size="icon" className="mb-8 lg:hidden">
+            <Button variant="outline" size="icon" className="mb-8 md:hidden">
               <Filter className="h-4 w-4" />
             </Button>
           </DrawerTrigger>
@@ -259,14 +259,14 @@ export function PortfolioLibrary() {
           </DrawerContent>
         </Drawer>
 
-        <div className="grid lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-4 gap-8">
           {/* Filters Sidebar */}
-          <div className="lg:col-span-1 hidden lg:block">
+          <div className="md:col-span-1 hidden md:block">
             <FilterControls {...filterControlsProps} />
           </div>
 
           {/* Projects Grid/List */}
-          <div className="lg:col-span-3">
+          <div className="md:col-span-3">
             <motion.div
               className="mb-6"
               initial={{ opacity: 0 }}

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -248,25 +248,27 @@ export function PortfolioLibrary() {
           )}
         </motion.div>
 
-        <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
-          <DrawerTrigger asChild>
-            <Button variant="outline" size="icon" className="mb-8 md:hidden">
-              <Filter className="h-4 w-4" />
-            </Button>
-          </DrawerTrigger>
-          <DrawerContent className="p-4">
-            <FilterControls {...filterControlsProps} className="block" />
-          </DrawerContent>
-        </Drawer>
+        <div className="lg:hidden">
+          <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
+            <DrawerTrigger asChild>
+              <Button variant="outline" size="icon" className="mb-8">
+                <Filter className="h-4 w-4" />
+              </Button>
+            </DrawerTrigger>
+            <DrawerContent className="p-4">
+              <FilterControls {...filterControlsProps} className="block" />
+            </DrawerContent>
+          </Drawer>
+        </div>
 
-        <div className="grid md:grid-cols-4 gap-8">
+        <div className="grid lg:grid-cols-4 gap-8">
           {/* Filters Sidebar */}
-          <div className="md:col-span-1 hidden md:block">
+          <div className="lg:col-span-1 hidden lg:block">
             <FilterControls {...filterControlsProps} />
           </div>
 
           {/* Projects Grid/List */}
-          <div className="md:col-span-3">
+          <div className="lg:col-span-3">
             <motion.div
               className="mb-6"
               initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- Remove automatic hiding from `FilterControls` so the sidebar is expanded on desktop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1558a0e08832286196ddacb666563