### PR TITLE
Show portfolio filters sidebar from md breakpoint

### DIFF
--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -250,7 +250,7 @@ export function PortfolioLibrary() {
 
         <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
           <DrawerTrigger asChild>
-            <Button variant="outline" size="icon" className="mb-8 lg:hidden">
+            <Button variant="outline" size="icon" className="mb-8 md:hidden">
               <Filter className="h-4 w-4" />
             </Button>
           </DrawerTrigger>
@@ -259,14 +259,14 @@ export function PortfolioLibrary() {
           </DrawerContent>
         </Drawer>
 
-        <div className="grid lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-4 gap-8">
           {/* Filters Sidebar */}
-          <div className="lg:col-span-1 hidden lg:block">
+          <div className="md:col-span-1 hidden md:block">
             <FilterControls {...filterControlsProps} />
           </div>
 
           {/* Projects Grid/List */}
-          <div className="lg:col-span-3">
+          <div className="md:col-span-3">
             <motion.div
               className="mb-6"
               initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- display portfolio filter sidebar starting at the medium breakpoint
- hide filter drawer button on medium and larger screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1655bfe788322b802c1bb965f08c5