### PR TITLE
Show portfolio filters sidebar from md breakpoint

### DIFF
--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -51,7 +51,7 @@ export function FilterControls({
   };
 
   return (
-    <div className={cn('hidden lg:block', className)}>
+    <div className={cn('md:block', className)}>
       <motion.div
         className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-4 sm:p-6 space-y-6"
         initial={{ opacity: 0, x: -20 }}

--- a/src/components/PortfolioLibrary.tsx
+++ b/src/components/PortfolioLibrary.tsx
@@ -248,25 +248,27 @@ export function PortfolioLibrary() {
           )}
         </motion.div>
 
-        <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
-          <DrawerTrigger asChild>
-            <Button variant="outline" size="icon" className="mb-8 lg:hidden">
-              <Filter className="h-4 w-4" />
-            </Button>
-          </DrawerTrigger>
-          <DrawerContent className="p-4">
-            <FilterControls {...filterControlsProps} className="block" />
-          </DrawerContent>
-        </Drawer>
+        <div className="md:hidden">
+          <Drawer open={isFilterOpen} onOpenChange={setIsFilterOpen} direction="left">
+            <DrawerTrigger asChild>
+              <Button variant="outline" size="icon" className="mb-8">
+                <Filter className="h-4 w-4" />
+              </Button>
+            </DrawerTrigger>
+            <DrawerContent className="p-4">
+              <FilterControls {...filterControlsProps} className="block" />
+            </DrawerContent>
+          </Drawer>
+        </div>
 
-        <div className="grid lg:grid-cols-4 gap-8">
+        <div className="md:grid md:grid-cols-[16rem_1fr] gap-8 items-start">
           {/* Filters Sidebar */}
-          <div className="lg:col-span-1 hidden lg:block">
+          <div className="hidden md:block md:sticky md:top-24">
             <FilterControls {...filterControlsProps} />
           </div>
 
           {/* Projects Grid/List */}
-          <div className="lg:col-span-3">
+          <div>
             <motion.div
               className="mb-6"
               initial={{ opacity: 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -6842,3 +6842,11 @@ html {
     opacity: 0;
   }
 }
+@media (width >= 48rem) {
+  .md\:hidden { display: none; }
+  .md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .md\:col-span-1 { grid-column: span 1 / span 1; }
+  .md\:col-span-3 { grid-column: span 3 / span 3; }
+  .md\:sticky { position: sticky; }
+  .md\:top-0 { top: 0; }
+}


### PR DESCRIPTION
## Summary
- ensure `FilterControls` renders from the medium breakpoint so the sidebar is visible on wider screens
- rebuild portfolio layout with a fixed 16 rem grid sidebar that stays sticky while projects fill the remaining space

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1655bfe788322b802c1bb965f08c5