### PR TITLE
Add admin avatar trigger in hero section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { motion } from 'motion/react';
+import adminAvatar from '../assets/admin-avatar.png';
 
 interface HeroData {
   name: string;
@@ -10,7 +10,6 @@ interface HeroData {
   primaryButtonText: string;
   secondaryButtonText: string;
   contactLink: string;
-  image: string;
 }
 
 const DEFAULT_HERO_DATA: HeroData = {
@@ -21,13 +20,11 @@ const DEFAULT_HERO_DATA: HeroData = {
   expertise: 'Client communication • Business process optimization • Visual concept creation • Social media promotion',
   primaryButtonText: 'View Portfolio',
   secondaryButtonText: 'Contact Me',
-  contactLink: 'https://t.me/artartemev',
-  image: ''
+  contactLink: 'https://t.me/artartemev'
 };
 
 export function Hero({ onUnlockAdmin }: { onUnlockAdmin?: () => void }) {
   const heroData = DEFAULT_HERO_DATA;
-  const [clickCount, setClickCount] = useState(0);
 
   const scrollToPortfolio = () => {
     const portfolioSection = document.querySelector('[data-section="portfolio"]');
@@ -36,15 +33,10 @@ export function Hero({ onUnlockAdmin }: { onUnlockAdmin?: () => void }) {
     }
   };
 
-  const handleImageClick = () => {
-    const newCount = clickCount + 1;
-    setClickCount(newCount);
-    if (newCount >= 8) {
-      const password = window.prompt('Enter admin password');
-      if (password === 'goura') {
-        onUnlockAdmin?.();
-      }
-      setClickCount(0);
+  const handleAdminClick = () => {
+    const password = window.prompt('Enter admin password');
+    if (password === 'goura') {
+      onUnlockAdmin?.();
     }
   };
   return (
@@ -81,51 +73,38 @@ export function Hero({ onUnlockAdmin }: { onUnlockAdmin?: () => void }) {
       </div>
 
       <div className="container mx-auto px-8 relative z-10">
-        <div className="grid lg:grid-cols-2 gap-16 items-center">
-          {/* Image Section */}
-          <motion.div
-            initial={{ opacity: 0, x: -50 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.8 }}
-            className="relative"
-          >
-            <div className="relative">
-              {heroData.image && (
-                <img
-                  src={heroData.image}
-                  alt={`${heroData.name} - ${heroData.title}`}
-                  className="w-full max-w-md mx-auto rounded-2xl shadow-2xl object-cover aspect-[4/5]"
-                  onClick={handleImageClick}
-                  loading="lazy"
-                />
-              )}
-            </div>
-          </motion.div>
-
-          {/* Content Section */}
+        <div className="flex items-center justify-center">
           <motion.div
             initial={{ opacity: 0, x: 50 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.8, delay: 0.2 }}
             className="space-y-8"
           >
-            <div className="space-y-4">
-              <motion.h1
-                className="font-['Anonymous_Pro'] tracking-[0.2em] uppercase text-[#323232]"
-                style={{ fontSize: 'clamp(2rem, 8vw, 6rem)', fontWeight: 'bold', lineHeight: '0.9' }}
-                initial={{ opacity: 0, y: 30 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.8, delay: 0.4 }}
-              >
-                {heroData.name}
-              </motion.h1>
-              
-              <motion.div
-                className="h-1 w-24 bg-gradient-to-r from-[#323232] to-transparent"
-                initial={{ width: 0 }}
-                animate={{ width: 96 }}
-                transition={{ duration: 0.8, delay: 0.6 }}
+            <div className="flex items-center gap-4">
+              <img
+                src={adminAvatar}
+                alt="Admin avatar"
+                className="w-16 h-16 rounded-full cursor-pointer"
+                onClick={handleAdminClick}
               />
+              <div className="space-y-4">
+                <motion.h1
+                  className="font-['Anonymous_Pro'] tracking-[0.2em] uppercase text-[#323232]"
+                  style={{ fontSize: 'clamp(2rem, 8vw, 6rem)', fontWeight: 'bold', lineHeight: '0.9' }}
+                  initial={{ opacity: 0, y: 30 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.8, delay: 0.4 }}
+                >
+                  {heroData.name}
+                </motion.h1>
+
+                <motion.div
+                  className="h-1 w-24 bg-gradient-to-r from-[#323232] to-transparent"
+                  initial={{ width: 0 }}
+                  animate={{ width: 96 }}
+                  transition={{ duration: 0.8, delay: 0.6 }}
+                />
+              </div>
             </div>
 
             <motion.div


### PR DESCRIPTION
## Summary
- add clickable admin avatar to hero section for unlocking admin panel
- simplify hero layout by removing unused hero image logic

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19427bc208322b811a53383c3d432