### PR TITLE
fix: enable project modal on mobile

### DIFF
--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -123,3 +123,5 @@ export function ProjectModal({ project, isOpen, onClose }: ProjectModalProps) {
     </>
   );
 }
+
+export default ProjectModal;


### PR DESCRIPTION
## Summary
- export ProjectModal as default to ensure lazy-loaded case studies open on mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1ac4605808322a7fcbe16c4d9fe0e